### PR TITLE
Upgrade to `exceptions-0.6`

### DIFF
--- a/pipes-safe.cabal
+++ b/pipes-safe.cabal
@@ -36,8 +36,8 @@ Library
     Build-Depends:
         base         >= 4       && < 5  ,
         containers   >= 0.3.0.0 && < 0.6,
-        exceptions   >= 0.4     && < 0.6,
-        transformers >= 0.2.0.0 && < 0.4,
+        exceptions   >= 0.6     && < 0.7,
+        transformers >= 0.2.0.0 && < 0.5,
         pipes        >= 4.0.0   && < 4.2
     Exposed-Modules:
         Pipes.Safe,


### PR DESCRIPTION
This also includes the upper limit bump for `tranformers`.

It compiles correctly but please don't trust it without having a look at it because I'm not that familiar with `pipes-safe` code.
