### PR TITLE
Minor updates

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,3 @@
+# Version 2.1.1
+
+* Raise upper-bound on `exceptions` dependency.

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,3 @@
-# Version 2.1.1
+# Version 2.2.1
 
 * Raise upper-bound on `exceptions` dependency.

--- a/pipes-safe.cabal
+++ b/pipes-safe.cabal
@@ -1,5 +1,5 @@
 Name: pipes-safe
-Version: 2.1.1
+Version: 2.2.1
 Cabal-Version: >=1.8.0.2
 Build-Type: Simple
 License: BSD3

--- a/pipes-safe.cabal
+++ b/pipes-safe.cabal
@@ -4,6 +4,7 @@ Cabal-Version: >=1.8.0.2
 Build-Type: Simple
 License: BSD3
 License-File: LICENSE
+Extra-Source-Files: README.md changelog.md
 Copyright: 2013, 2014 Gabriel Gonzalez
 Author: Gabriel Gonzalez
 Maintainer: Gabriel439@gmail.com

--- a/pipes-safe.cabal
+++ b/pipes-safe.cabal
@@ -1,5 +1,5 @@
 Name: pipes-safe
-Version: 2.1.0
+Version: 2.1.1
 Cabal-Version: >=1.8.0.2
 Build-Type: Simple
 License: BSD3
@@ -36,7 +36,7 @@ Library
     Build-Depends:
         base         >= 4       && < 5  ,
         containers   >= 0.3.0.0 && < 0.6,
-        exceptions   >= 0.6     && < 0.7,
+        exceptions   >= 0.6     && < 0.8,
         transformers >= 0.2.0.0 && < 0.5,
         pipes        >= 4.0.0   && < 4.2
     Exposed-Modules:

--- a/src/Pipes/Safe.hs
+++ b/src/Pipes/Safe.hs
@@ -123,7 +123,7 @@ import Data.IORef (IORef, newIORef, readIORef, writeIORef)
 import qualified Data.Map as M
 import Data.Monoid (Monoid)
 import Pipes (Proxy, Effect, Effect', runEffect)
-import Pipes.Internal (unsafeHoist, Proxy(..))
+import Pipes.Internal (Proxy(..))
 import Pipes.Lift (liftCatchError)
 
 data Restore m = Unmasked | Masked (forall x . m x -> m x)
@@ -146,7 +146,7 @@ liftMask maskVariant k = do
             liftIO $ writeIORef ioref $ Masked unmaskVariant
             m >>= chunk >>= return . loop
         loop (Pure r)         = Pure r
-      
+
         -- unmask adjacent actions in base monad
         unmask :: forall q. Proxy a' a b' b m q -> Proxy a' a b' b m q
         unmask (Request a' fa ) = Request a' (unmask . fa )


### PR DESCRIPTION
@Gabriel439 I share some minor updates here:

* I bumped the upper-bound dependency on `exceptions` (see https://github.com/fpco/stackage/issues/443). No other dependencies need updating (http://packdeps.haskellers.com/feed?needle=pipes-safe)

* I removed an unused import GHC was complaining about when compiling the package.

* I noticed the package was missing a `changelog.md` file, which when named like that, is readily picked up by `Hackage` and linked from the package's description page. I took the liberty of adding it for you so that it is easier for users of your library to know what are the changes between versions.

* I increased the version number to `2.1.1` so that you can readily ship this.

Please let me know if you think I should change something here.

Thanks.