### PR TITLE
MonadBaseControl and other instances for SafeT

### DIFF
--- a/pipes-safe.cabal
+++ b/pipes-safe.cabal
@@ -35,11 +35,14 @@ Source-Repository head
 
 Library
     Build-Depends:
-        base         >= 4       && < 5  ,
-        containers   >= 0.3.0.0 && < 0.6,
-        exceptions   >= 0.6     && < 0.9,
-        transformers >= 0.2.0.0 && < 0.5,
-        pipes        >= 4.0.0   && < 4.2
+        base              >= 4       && < 5  ,
+        containers        >= 0.3.0.0 && < 0.6,
+        exceptions        >= 0.6     && < 0.9,
+        mtl               >= 2.1     && < 2.3,
+        transformers      >= 0.2.0.0 && < 0.5,
+        transformers-base >= 0.4.4   && < 0.5,
+        monad-control     >= 1.0.0.4 && < 1.1,
+        pipes             >= 4.0.0   && < 4.2
     Exposed-Modules:
         Pipes.Safe,
         Pipes.Safe.Prelude

--- a/src/Pipes/Safe.hs
+++ b/src/Pipes/Safe.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE RankNTypes, TypeFamilies, FlexibleContexts, FlexibleInstances,
       MultiParamTypeClasses, UndecidableInstances, ScopedTypeVariables,
-      GeneralizedNewtypeDeriving, CPP, DeriveDataTypeable #-}
+      GeneralizedNewtypeDeriving, CPP #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 {-| This module provides an orphan 'MonadCatch' instance for 'Proxy' of the
@@ -131,7 +131,6 @@ import qualified Control.Monad.Writer.Class        as WC
 import Data.IORef (IORef, newIORef, readIORef, writeIORef, atomicModifyIORef')
 import qualified Data.Map as M
 import Data.Monoid (Monoid)
-import Data.Typeable (Typeable)
 import Pipes (Proxy, Effect, Effect', runEffect)
 import Pipes.Internal (Proxy(..))
 import Pipes.Lift (liftCatchError)
@@ -196,7 +195,7 @@ data Finalizers m = Finalizers
     in the event of exceptions.
 -}
 newtype SafeT m r = SafeT { unSafeT :: R.ReaderT (IORef (Maybe (Finalizers m))) m r }
-    deriving (Typeable, Functor, Applicative, Alternative, Monad, MonadPlus,
+    deriving (Functor, Applicative, Alternative, Monad, MonadPlus,
               EC.MonadError e, SC.MonadState s, WC.MonadWriter w, CC.MonadCont,
               MonadThrow, MonadCatch, MonadMask, MonadIO, B.MonadBase b)
 


### PR DESCRIPTION
A main difference between SafeT's implementation of MonadBaseControl, and that of ResourceT: ResourceT allows a reference counting mechanism so that multiple threads can share the same resource environment, but where resources are only freed once the last thread has finished executing.

I'm not sure yet if we need this behavior, so I haven't coded in support (though it will be fairly easy to add later). Instead, and as before, runSafeT governs the lifetime of resources. If you spawn threads in a runSafeT block and they allocate resources, those resources are freed when runSafeT ends, even if those threads are still running (which means they could now reference freed resources). If the child threads attempt to acquire or release resources beyond that point, it raises an error.

Therefore, the only safe way to mix forkIO with SafeT (via MonadBaseControl) is to ensure that the thread executing runSafeT either waits until all other threads have been completed before allowing runSafeT to complete, or cancels all those threads before it exits.

@Gabriel439 The reason I'm submitting this support is that I'm working on a [`pipes-async` library](https://github.com/jwiegley/pipes-async/blob/master/Pipes/Async.hs#L20), supporting higher-level constructs like a dead simple `>&>` operator, which uses `lifted-base` and `lifted-async` to manage concurrency and exception handling.  These require `MonadBaseControl IO`.