### PR TITLE
Remove instances for MonadThrow and MonadCatch, add tryP/catchP

### DIFF
--- a/pipes-safe.cabal
+++ b/pipes-safe.cabal
@@ -43,7 +43,7 @@ Library
         transformers      >= 0.2.0.0 && < 0.6,
         transformers-base >= 0.4.4   && < 0.5,
         monad-control     >= 1.0.0.4 && < 1.1,
-        pipes             >= 4.0.0   && < 4.3
+        pipes             >= 4.2.1   && < 4.3
     Exposed-Modules:
         Pipes.Safe,
         Pipes.Safe.Prelude

--- a/src/Pipes/Safe.hs
+++ b/src/Pipes/Safe.hs
@@ -179,12 +179,6 @@ liftMask maskVariant k = do
 
     loop $ k unmask
 
-instance (MonadThrow m) => MonadThrow (Proxy a' a b' b m) where
-    throwM = lift . throwM
-
-instance (MonadCatch m) => MonadCatch (Proxy a' a b' b m) where
-    catch = liftCatchError C.catch
-
 instance (MonadMask m, MonadIO m) => MonadMask (Proxy a' a b' b m) where
     mask                = liftMask mask
     uninterruptibleMask = liftMask uninterruptibleMask


### PR DESCRIPTION
This goes along with my other pull request in `pipes`: https://github.com/Gabriel439/Haskell-Pipes-Library/pull/180
