### PR TITLE
Add PrimMonad instance for SafeT

### DIFF
--- a/pipes-safe.cabal
+++ b/pipes-safe.cabal
@@ -43,6 +43,7 @@ Library
         transformers      >= 0.2.0.0 && < 0.6,
         transformers-base >= 0.4.4   && < 0.5,
         monad-control     >= 1.0.0.4 && < 1.1,
+        primitive         >= 0.6.2.0 && < 0.7,
         pipes             >= 4.3.0   && < 4.4
     Exposed-Modules:
         Pipes.Safe,

--- a/src/Pipes/Safe.hs
+++ b/src/Pipes/Safe.hs
@@ -121,6 +121,7 @@ import qualified Control.Monad.Catch.Pure          as E
 import qualified Control.Monad.Trans.Identity      as I
 import qualified Control.Monad.Cont.Class          as CC
 import qualified Control.Monad.Error.Class         as EC
+import qualified Control.Monad.Primitive           as Prim
 import qualified Control.Monad.Trans.Reader        as R
 import qualified Control.Monad.Trans.RWS.Lazy      as RWS
 import qualified Control.Monad.Trans.RWS.Strict    as RWS'
@@ -216,6 +217,11 @@ instance MonadBaseControl b m => MonadBaseControl b (SafeT m) where
              f $ liftM StMT . runInBase . \(SafeT r) -> R.runReaderT r reader'
      restoreM (StMT base) = SafeT $ R.ReaderT $ const $ restoreM base
 #endif
+
+instance Prim.PrimMonad m => Prim.PrimMonad (SafeT m) where
+  type PrimState (SafeT m) = Prim.PrimState m
+  primitive = lift . Prim.primitive
+  {-# INLINE primitive #-}
 
 {-| Run the 'SafeT' monad transformer, executing all unreleased finalizers at
     the end of the computation


### PR DESCRIPTION
I found this useful when reading data using `SafeT` into `Vector`s.