### PR TITLE
Remove ghc 7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,6 @@ before_cache:
 
 matrix:
   include:
-    - env: CABALVER=1.16 GHCVER=7.4.2
-      compiler: ": #GHC 7.4.2"
-      addons: {apt: {packages: [cabal-install-1.16,ghc-7.4.2], sources: [hvr-ghc]}}
     - env: CABALVER=1.16 GHCVER=7.6.3
       compiler: ": #GHC 7.6.3"
       addons: {apt: {packages: [cabal-install-1.16,ghc-7.6.3], sources: [hvr-ghc]}}

--- a/pipes-safe.cabal
+++ b/pipes-safe.cabal
@@ -36,7 +36,7 @@ Source-Repository head
 
 Library
     Build-Depends:
-        base              >= 4       && < 5   ,
+        base              >= 4.6     && < 5   ,
         containers        >= 0.3.0.0 && < 0.6 ,
         exceptions        >= 0.6     && < 0.11,
         mtl               >= 2.1     && < 2.3 ,


### PR DESCRIPTION
This package doesn't build on GHC 7.4, so I've updated the base bound.
If you're still interested in maintaining support for GHC 7.4, I'm happy to write that pull request instead.

By the way, it looks like there hasn't been a Travis CI build for this repo in some time (hence the 7.4 breakage slipped through). Is that intentional?

Speaking of Travis, I'd like to run the updated travis script to get a `cabal new-build` based travis build, and include newer GHC versions. Would you be interested in me making that PR?