### PR TITLE
Bump for GHC 8.6.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,9 @@ before_cache:
 
 matrix:
   include:
+    - compiler: "ghc-8.6.1"
+    # env: TEST=--disable-tests BENCH=--disable-benchmarks
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.2,ghc-8.6.1], sources: [hvr-ghc]}}
     - compiler: "ghc-8.4.3"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.2,ghc-8.4.3], sources: [hvr-ghc]}}

--- a/pipes-safe.cabal
+++ b/pipes-safe.cabal
@@ -45,6 +45,9 @@ Library
         monad-control     >= 1.0.0.4 && < 1.1 ,
         primitive         >= 0.6.2.0 && < 0.7 ,
         pipes             >= 4.3.0   && < 4.4
+    if impl(ghc < 8.0)
+        Build-Depends:
+            fail                        < 4.10
     Exposed-Modules:
         Pipes.Safe,
         Pipes.Safe.Prelude

--- a/pipes-safe.cabal
+++ b/pipes-safe.cabal
@@ -37,7 +37,7 @@ Source-Repository head
 Library
     Build-Depends:
         base              >= 4.8     && < 5   ,
-        containers        >= 0.3.0.0 && < 0.6 ,
+        containers        >= 0.3.0.0 && < 0.7 ,
         exceptions        >= 0.6     && < 0.11,
         mtl               >= 2.1     && < 2.3 ,
         transformers      >= 0.2.0.0 && < 0.6 ,

--- a/src/Pipes/Safe/Prelude.hs
+++ b/src/Pipes/Safe/Prelude.hs
@@ -12,6 +12,7 @@ module Pipes.Safe.Prelude (
     writeFile
     ) where
 
+import Control.Monad.Fail (MonadFail)
 import Control.Monad.IO.Class (MonadIO(liftIO))
 import Pipes (Producer', Consumer')
 import Pipes.Safe (bracket, MonadSafe)
@@ -34,13 +35,13 @@ withFile file ioMode = bracket (liftIO $ IO.openFile file ioMode) (liftIO . IO.h
 {-| Read lines from a file, automatically opening and closing the file as
     necessary
 -}
-readFile :: (MonadSafe m) => FilePath -> Producer' String m ()
+readFile :: (MonadSafe m, MonadFail m) => FilePath -> Producer' String m ()
 readFile file = withFile file IO.ReadMode P.fromHandle
 {-# INLINABLE readFile #-}
 
 {-| Write lines to a file, automatically opening and closing the file as
     necessary
 -}
-writeFile :: (MonadSafe m) => FilePath -> Consumer' String m r
+writeFile :: (MonadSafe m, MonadFail m) => FilePath -> Consumer' String m r
 writeFile file = withFile file IO.WriteMode P.toHandle
 {-# INLINABLE writeFile #-}


### PR DESCRIPTION
This requires some `MonadFail` instances, because of a pattern match that might otherwise fail in a `do`-block.