### PR TITLE
Derive `MonadFail` instance

### DIFF
--- a/src/Pipes/Safe.hs
+++ b/src/Pipes/Safe.hs
@@ -217,9 +217,24 @@ data Finalizers m = Finalizers
     in the event of exceptions.
 -}
 newtype SafeT m r = SafeT { unSafeT :: R.ReaderT (IORef (Maybe (Finalizers m))) m r }
-    deriving (Functor, Applicative, Alternative, Monad, MonadPlus, MonadFix,
-              EC.MonadError e, SC.MonadState s, WC.MonadWriter w, CC.MonadCont,
-              MonadThrow, MonadCatch, MonadMask, MonadIO, B.MonadBase b)
+    deriving
+    ( Functor
+    , Applicative
+    , Alternative
+    , Monad
+    , MonadFail
+    , MonadPlus
+    , MonadFix
+    , EC.MonadError e
+    , SC.MonadState s
+    , WC.MonadWriter w
+    , CC.MonadCont
+    , MonadThrow
+    , MonadCatch
+    , MonadMask
+    , MonadIO
+    , B.MonadBase b
+    )
 
 instance MonadTrans SafeT where
     lift m = SafeT (lift m)

--- a/src/Pipes/Safe.hs
+++ b/src/Pipes/Safe.hs
@@ -222,7 +222,11 @@ newtype SafeT m r = SafeT { unSafeT :: R.ReaderT (IORef (Maybe (Finalizers m))) 
     , Applicative
     , Alternative
     , Monad
+-- The derived instance for `MonadFail` requires a `MonadFail` instance for
+-- `ReaderT` which is first available in `transformers-0.5.0.0`
+#if MIN_VERSION_transformers(0,5,0)
     , MonadFail
+#endif
     , MonadPlus
     , MonadFix
     , EC.MonadError e


### PR DESCRIPTION
This allows `readFile` and `writeFile` to work with `SafeT`