### PR TITLE
support GHC 9.0

### DIFF
--- a/src/Pipes/Safe.hs
+++ b/src/Pipes/Safe.hs
@@ -290,7 +290,7 @@ runSafeT m = C.bracket
     finalization without exiting the 'Proxy' monad.
 -}
 runSafeP :: (MonadMask m, MonadIO m) => Effect (SafeT m) r -> Effect' m r
-runSafeP = lift . runSafeT . runEffect
+runSafeP e = lift . runSafeT . runEffect $ e
 {-# INLINABLE runSafeP #-}
 
 -- | Token used to 'release' a previously 'register'ed finalizer

--- a/src/Pipes/Safe/Prelude.hs
+++ b/src/Pipes/Safe/Prelude.hs
@@ -42,5 +42,5 @@ readFile file = withFile file IO.ReadMode P.fromHandle
     necessary
 -}
 writeFile :: MonadSafe m => FilePath -> Consumer' String m r
-writeFile file = withFile file IO.WriteMode P.toHandle
+writeFile file = withFile file IO.WriteMode $ \h -> P.toHandle h
 {-# INLINABLE writeFile #-}


### PR DESCRIPTION
two trivial changes due to [simplified subsumption](https://gitlab.haskell.org/ghc/ghc/-/wikis/migration/9.0#simplified-subsumption)

Tested locally with
```
cabal build -w ghc-9.0.1
```