### PR TITLE
CI with GitHub Actions

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -1,0 +1,41 @@
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+name: Haskell CI
+
+jobs:
+  build:
+    name: Test
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        ghc: ['8.10', '9.0', '9.2']
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: haskell/actions/setup@v1.2
+      with:
+        ghc-version: ${{ matrix.ghc }}
+    - name: Cache
+      uses: actions/cache@v1
+      env:
+        cache-name: cache-cabal
+      with:
+        path: ~/.cabal
+        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/*.cabal') }}-${{ hashFiles('**/cabal.project') }}
+        restore-keys: |
+          ${{ runner.os }}-build-${{ env.cache-name }}-
+          ${{ runner.os }}-build-
+          ${{ runner.os }}-
+    - name: Install dependencies
+      run: |
+        cabal update
+        cabal build --only-dependencies --enable-tests --enable-benchmarks --project-file ./configurations/ghc-${{ matrix.ghc }}.project
+    - name: Build
+      run: cabal build --enable-tests --enable-benchmarks all --project-file ./configurations/ghc-${{ matrix.ghc }}.project
+    - name: Run tests
+      run: cabal test all --project-file ./configurations/ghc-${{ matrix.ghc }}.project

--- a/configurations/ghc-8.10.project
+++ b/configurations/ghc-8.10.project
@@ -1,0 +1,12 @@
+packages: ./pipes-safe.cabal
+
+constraints:
+    base == 4.14.*
+  , containers == 0.6.2.1
+  , exceptions == 0.10.4
+  , mtl == 2.2.2
+  , transformers == 0.5.6.2
+  , transformers-base == 0.4.4
+  , monad-control == 1.0.0.4
+  , primitive == 0.7.0.0
+  , pipes == 4.3.10

--- a/configurations/ghc-9.0.project
+++ b/configurations/ghc-9.0.project
@@ -1,0 +1,4 @@
+packages: ./pipes-safe.cabal
+
+constraints:
+    base == 4.15.*

--- a/configurations/ghc-9.2.project
+++ b/configurations/ghc-9.2.project
@@ -1,0 +1,4 @@
+packages: ./pipes-safe.cabal
+
+constraints:
+    base == 4.16.*

--- a/pipes-safe.cabal
+++ b/pipes-safe.cabal
@@ -8,7 +8,7 @@ Extra-Source-Files: README.md changelog.md
 Copyright: 2013, 2014 Gabriel Gonzalez
 Author: Gabriel Gonzalez
 Maintainer: Gabriel439@gmail.com
-Tested-With: GHC == 7.10.3, GHC == 8.0.2, GHC == 8.2.2, GHC == 8.4.3
+Tested-With: GHC == 8.10.7, GHC == 9.0.2, GHC == 9.2.1
 Bug-Reports: https://github.com/Gabriel439/Haskell-Pipes-Safe-Library/issues
 Synopsis: Safety for the pipes ecosystem
 Description:
@@ -36,18 +36,15 @@ Source-Repository head
 
 Library
     Build-Depends:
-        base              >= 4.8     && < 5   ,
-        containers        >= 0.3.0.0 && < 0.7 ,
-        exceptions        >= 0.6     && < 0.11,
-        mtl               >= 2.1     && < 2.3 ,
-        transformers      >= 0.2.0.0 && < 0.6 ,
+        base              >= 4.14    && < 4.17,
+        containers        >= 0.6.2.1 && < 0.7 ,
+        exceptions        >= 0.10.4  && < 0.11,
+        mtl               >= 2.2.2   && < 2.3 ,
+        transformers      >= 0.5.6.2 && < 0.6 ,
         transformers-base >= 0.4.4   && < 0.5 ,
         monad-control     >= 1.0.0.4 && < 1.1 ,
-        primitive         >= 0.6.2.0 && < 0.8 ,
-        pipes             >= 4.3.0   && < 4.4
-    if impl(ghc < 8.0)
-        Build-Depends:
-            fail                        < 4.10
+        primitive         >= 0.7.0.0 && < 0.8 ,
+        pipes             >= 4.3.10  && < 4.4
     Exposed-Modules:
         Pipes.Safe,
         Pipes.Safe.Prelude


### PR DESCRIPTION
The build matrix tests all the supported GHC versions, based on the supported versions of `base` given in the cabal file.

I like to test with cabal file for each build so that I can put in constraints to ensure that the CI is testing as many versions that the cabal file declares to be in bounds as possible. I haven't done that very much here, but I have put in constraints for the oldest build to test minimum bounds. The second commit raises the minimum bounds to reflect what is actually testable with GHC 7.10. Anyway, those are just my preferences, but thought I'd offer.