### PR TITLE
Add allocate, allocate_, openFile

### DIFF
--- a/src/Pipes/Safe/Prelude.hs
+++ b/src/Pipes/Safe/Prelude.hs
@@ -5,16 +5,22 @@
 module Pipes.Safe.Prelude (
     -- * Handle management
     withFile,
+    openFile,
 
     -- * String I/O
     -- $strings
     readFile,
-    writeFile
+    writeFile,
+
+    -- * Registering/releasing
+    allocate,
+    allocate_
     ) where
 
+import Control.Monad.Catch (mask_)
 import Control.Monad.IO.Class (MonadIO(liftIO))
 import Pipes (Producer', Consumer')
-import Pipes.Safe (bracket, MonadSafe)
+import Pipes.Safe (bracket, liftBase, register, Base, MonadSafe, ReleaseKey)
 import qualified Pipes.Prelude as P
 import qualified System.IO as IO
 import Prelude hiding (readFile, writeFile)
@@ -23,6 +29,16 @@ import Prelude hiding (readFile, writeFile)
 withFile :: (MonadSafe m) => FilePath -> IO.IOMode -> (IO.Handle -> m r) -> m r
 withFile file ioMode = bracket (liftIO $ IO.openFile file ioMode) (liftIO . IO.hClose)
 {-# INLINABLE withFile #-}
+
+{- | Acquire a 'IO.Handle' within 'MonadSafe'
+
+     The 'ReleaseKey' can be used to close the handle with 'Pipes.Safe.release';
+     otherwise the handle will be closed automatically at the conclusion of the
+     'MonadSafe' block.
+-}
+openFile :: MonadSafe m => FilePath -> IO.IOMode -> m (ReleaseKey, IO.Handle)
+openFile file ioMode = allocate (liftIO $ IO.openFile file ioMode) (liftIO . IO.hClose)
+{-# INLINABLE openFile #-}
 
 {- $strings
     Note that 'String's are very inefficient, and I will release future separate
@@ -44,3 +60,31 @@ readFile file = withFile file IO.ReadMode P.fromHandle
 writeFile :: MonadSafe m => FilePath -> Consumer' String m r
 writeFile file = withFile file IO.WriteMode $ \h -> P.toHandle h
 {-# INLINABLE writeFile #-}
+
+{- | Acquire some resource with a guarantee that it will eventually be released
+
+     The 'ReleaseKey' can be passed to 'Pipes.Safe.release' to
+     release the resource manually. If this has not been done by the end
+     of the 'MonadSafe' block, the resource will be released automatically.
+-}
+allocate :: MonadSafe m =>
+    Base m a             -- ^ Acquire
+    -> (a -> Base m ())  -- ^ Release
+    -> m (ReleaseKey, a)
+allocate acq rel = mask_ $ do
+    a <- liftBase acq
+    key <- register (rel a)
+    return (key, a)
+
+{- | Like 'allocate', but for when the resource itself is not needed
+
+     The acquire  action runs immediately. The 'ReleaseKey' can be passed
+     to 'Pipes.Safe.release' to run the release action. If this has not been
+     done by the end of the 'MonadSafe' block, the release action will be
+     run automatically.
+-}
+allocate_ :: MonadSafe m =>
+    Base m a        -- ^ Acquire
+    -> (Base m ())  -- ^ Release
+    -> m ReleaseKey
+allocate_ acq rel = fmap fst (allocate acq (const rel))


### PR DESCRIPTION
For context, my motivation is that I'm considering using `SafeT` as an introductory monad transformer example (prior to introducing `pipes`), using it to manage file handles and emphasizing how it lets you keep using `do` blocks instead of explicitly nesting continuations in the style of `withFile`. At first I was going to introduce [`ResourceT`](https://hackage.haskell.org/package/resourcet/docs/Control-Monad-Trans-Resource.html), but then I started to figure it would be simpler to stay within the Pipes ecosystem. Having the `allocate` function already available in the library would avoid a significant diversion into explaining exception masking and make this a heck of a lot easier. I think it also contributes to generally making it easier for users of `SafeT` to understand what it is capable of.

The `allocate` and `allocate_` functions are modeled after the `resourcet` library.

`allocate_` and `openFile` are not as essential as `allocate`, but seemed like nice bonuses.

`allocate` and `allocate_` might belong better in `Pipes.Safe` instead of `Pipes.Safe.Prelude`, but I wasn't sure how to make that judgement.

I added an `inlinable` pragma to `openFile` because there is one on `withFile`, but I have to confess I don't really understand why the pragmas are there, so I don't know if there should be more or fewer of them on the definitions I have added.

I believe this would close #21.