### PR TITLE
Make it build with ghc-9.10

### DIFF
--- a/pipes-safe.cabal
+++ b/pipes-safe.cabal
@@ -36,7 +36,7 @@ Source-Repository head
 
 Library
     Build-Depends:
-        base              >= 4.14    && < 4.20,
+        base              >= 4.14    && < 4.21,
         containers        >= 0.6.2.1 && < 0.8 ,
         exceptions        >= 0.10.4  && < 0.11,
         mtl               >= 2.2.2   && < 2.4 ,


### PR DESCRIPTION
Only needs a bump to the `base` dependency. Would appreciate a Hackage metadata edit as well.

With your ok, I can (as a Hackage Trustee) do the metadata edit for you.